### PR TITLE
Fix typo and messages.json fixture

### DIFF
--- a/draft-kalos-bbs-blind-signatures.md
+++ b/draft-kalos-bbs-blind-signatures.md
@@ -456,7 +456,7 @@ Deserialization:
 4. for i in disclosed_indexes, if i < 0 or i >= L, return INVALID
 5. if length(disclosed_commitment_indexes) > M, return INVALID
 6. for j in disclosed_commitment_indexes,
-                               if i < 0 or i >= L, return INVALID
+                               if i < 0 or i >= M, return INVALID
 
 Procedure:
 

--- a/fixtures/fixture_data/messages.json
+++ b/fixtures/fixture_data/messages.json
@@ -12,10 +12,10 @@
         ""
     ],
     "committedMessages": [
-        "9872ad089e452c7b6e283dfac2a80d58e8d0ff71cc4d5e310a1debdda4a45f02",
-        "089e452c7b6e283dfac2a80d58e8d0ff71cc4d5e310a1debdda4a45f02",
-        "7b6e283dfac2a80d58e8d0ff71cc4d5e310a1debdda4a45f02",
-        "fac2a80d58e8d0ff71cc4d5e310a1debdda4a45f02",
+        "5982967821da3c5983496214df36aa5e58de6fa25314af4cf4c00400779f08c3",
+        "a75d8b634891af92282cc81a675972d1929d3149863c1fc0",
+        "835889a40744813a892eff9deb1edaeb",
+        "e1ca9729410dc6ba",
         ""
     ]
 }


### PR DESCRIPTION
Hello, I fixed a typo in the deserialization section of `BlindProofGen`, and the `messages.json` fixture has been updated with the correct data, ensuring coherence with the data in the other fixtures.

I believe there is still an issue with the `proof008.json` fixture. In my implementation, it's the only test vector that fails. Upon investigation, I discovered that it fails due to incorrect computation of the random scalars. Thefixture refers to the scalars generated with a value of U = 6 (`random_scalars = calculate_random_scalars(5+U)`) in CoreProofGen, but I believe it should be 5 instead of 6.